### PR TITLE
feat(services): Add CRUD Services for Subscription and Payment Management

### DIFF
--- a/src/core/services/subscriptions/payment.service.ts
+++ b/src/core/services/subscriptions/payment.service.ts
@@ -1,0 +1,86 @@
+import { PrismaClient } from "@prisma/client";
+
+import { ErrorMessage } from "../../../adapters/api/errors/errors.enum";
+import { InternalServerError } from "../../../adapters/api/errors/internal_server.error";
+import { prismaGlobalExceptionFilter } from "../../../adapters/api/errors/prisma_global_exception_filter";
+import { PaymentEntity } from "../../entities/subscriptions/payment.entity";
+import { PaymentSearchCriteriaInput, UpdatePaymentInput } from "../../types/subscriptions/payment.types";
+
+export const findPaymentService = async (
+  client: PrismaClient,
+  searchCriteria: PaymentSearchCriteriaInput,
+): Promise<PaymentEntity | null> => {
+  try {
+    const { id } = searchCriteria;
+    const record = await client.payment.findUnique({ where: { payment_id: id } });
+
+    return record ? PaymentEntity.fromPrisma(record) : null;
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const createPaymentService = async (client: PrismaClient, payment: PaymentEntity): Promise<PaymentEntity> => {
+  try {
+    const record = await client.payment.create({
+      data: {
+        payment_id: payment.getId(),
+        payment_subscription_id: payment.getSubscriptionId(),
+        payment_amount: payment.getAmount(),
+        payment_currency: payment.getCurrency(),
+        payment_date: payment.getDate(),
+        payment_external_payment_id: payment.getExternalPaymentId(),
+        payment_status: payment.getStatus(),
+        payment_organization_client_id: payment.getOrganizationClientId(),
+      },
+    });
+
+    return PaymentEntity.fromPrisma(record);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const updatePaymentService = async (
+  client: PrismaClient,
+  searchCriteria: PaymentSearchCriteriaInput,
+  payment: UpdatePaymentInput,
+): Promise<PaymentEntity> => {
+  try {
+    const { id } = searchCriteria;
+    const record = await client.payment.update({
+      where: {
+        payment_id: id,
+      },
+      data: {
+        payment_amount: payment.amount,
+        payment_currency: payment.currency,
+        payment_date: payment.date,
+        payment_external_payment_id: payment.externalPaymentId,
+        payment_status: payment.status,
+      },
+    });
+
+    return PaymentEntity.fromPrisma(record);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const deletePaymentService = async (
+  client: PrismaClient,
+  searchCriteria: PaymentSearchCriteriaInput,
+): Promise<PaymentEntity> => {
+  try {
+    const { id } = searchCriteria;
+    const record = await client.payment.delete({ where: { payment_id: id } });
+
+    return PaymentEntity.fromPrisma(record);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};

--- a/src/core/services/subscriptions/subscription.service.ts
+++ b/src/core/services/subscriptions/subscription.service.ts
@@ -1,0 +1,108 @@
+import { PrismaClient } from "@prisma/client";
+
+import { ErrorMessage } from "../../../adapters/api/errors/errors.enum";
+import { InternalServerError } from "../../../adapters/api/errors/internal_server.error";
+import { prismaGlobalExceptionFilter } from "../../../adapters/api/errors/prisma_global_exception_filter";
+import { SubscriptionEntity } from "../../entities/subscriptions/subscription.entity";
+import {
+  SubscriptionSearchCriteriaInput,
+  UpdateSubscriptionInput,
+} from "../../types/subscriptions/subscripition.types";
+
+export const findSubscriptionService = async (
+  client: PrismaClient,
+  searchCriteria: SubscriptionSearchCriteriaInput,
+): Promise<SubscriptionEntity | null> => {
+  try {
+    const { id } = searchCriteria;
+    const record = await client.subscription.findUnique({
+      where: {
+        subscriptions_id: id,
+      },
+    });
+
+    return record ? SubscriptionEntity.fromPrisma(record) : null;
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const createSubscriptionService = async (
+  client: PrismaClient,
+  subscription: SubscriptionEntity,
+): Promise<SubscriptionEntity> => {
+  try {
+    const record = client.subscription.create({
+      data: {
+        subscriptions_user_id: subscription.getUserId(),
+        subscriptions_subscription_plan_id: subscription.getSubscriptionPlanId(),
+        subscriptions_external_subscription_id: subscription.getExternalSubscriptionId(),
+        subscriptions_billing_cycle: subscription.getBillingCycle(),
+        subscriptions_status: subscription.getStatus(),
+        subscriptions_is_active: subscription.getIsActive(),
+        subscriptions_renews_at: subscription.getRenewsAt(),
+        subscriptions_starts_at: subscription.getStartsAt(),
+        subscriptions_ends_at: subscription.getEndsAt(),
+        subscriptions_organization_client_id: subscription.getOrganizationClientId(),
+      },
+    });
+
+    const [recordCreated] = await client.$transaction([record]);
+    return SubscriptionEntity.fromPrisma(recordCreated);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const updateSubscriptionService = async (
+  client: PrismaClient,
+  searchCriteria: SubscriptionSearchCriteriaInput,
+  subscription: UpdateSubscriptionInput,
+): Promise<SubscriptionEntity> => {
+  try {
+    const record = client.subscription.update({
+      where: {
+        subscriptions_id: searchCriteria.id,
+      },
+      data: {
+        subscriptions_user_id: subscription.userId,
+        subscriptions_subscription_plan_id: subscription.subscriptionPlanId,
+        subscriptions_external_subscription_id: subscription.externalSubscriptionId,
+        subscriptions_billing_cycle: subscription.billingCycle,
+        subscriptions_status: subscription.status,
+        subscriptions_is_active: subscription.isActive,
+        subscriptions_renews_at: subscription.renewsAt,
+        subscriptions_starts_at: subscription.startsAt,
+        subscriptions_ends_at: subscription.endsAt,
+      },
+    });
+
+    const [recordUpdated] = await client.$transaction([record]);
+    return SubscriptionEntity.fromPrisma(recordUpdated);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};
+
+export const deleteSubscriptionService = async (
+  client: PrismaClient,
+  searchCriteria: SubscriptionSearchCriteriaInput,
+): Promise<SubscriptionEntity> => {
+  try {
+    const { id } = searchCriteria;
+    const record = client.subscription.delete({
+      where: {
+        subscriptions_id: id,
+      },
+    });
+
+    const [recordDeleted] = await client.$transaction([record]);
+    return SubscriptionEntity.fromPrisma(recordDeleted);
+  } catch (error) {
+    prismaGlobalExceptionFilter(error);
+    throw new InternalServerError(ErrorMessage.INTERNAL_SERVER_ERROR);
+  }
+};

--- a/src/core/types/subscriptions/payment.types.ts
+++ b/src/core/types/subscriptions/payment.types.ts
@@ -1,0 +1,14 @@
+export interface PaymentSearchCriteriaInput {
+  id: string;
+}
+
+export interface UpdatePaymentInput {
+  id?: string;
+  subscriptionId?: string;
+  amount?: number;
+  currency?: string;
+  date?: Date;
+  externalPaymentId?: string;
+  status?: string;
+  organizationClientId?: string;
+}

--- a/src/core/types/subscriptions/subscripition.types.ts
+++ b/src/core/types/subscriptions/subscripition.types.ts
@@ -1,0 +1,16 @@
+export interface SubscriptionSearchCriteriaInput {
+  id: string;
+}
+
+export interface UpdateSubscriptionInput {
+  userId?: string;
+  subscriptionPlanId?: string;
+  externalSubscriptionId?: string;
+  billingCycle?: string;
+  status?: string;
+  isActive?: boolean;
+  renewsAt?: Date;
+  startsAt?: Date;
+  endsAt?: Date;
+  organizationClientId?: string;
+}

--- a/tests/mocks/subscriptions/payment.mock.ts
+++ b/tests/mocks/subscriptions/payment.mock.ts
@@ -5,7 +5,7 @@ import { PaymentPrisma } from "../../../src/core/entities/subscriptions/payment.
 export const genRandomPaymentPrisma = ({
   payment_id = faker.string.uuid(),
   payment_subscription_id = faker.string.uuid(),
-  payment_amount = faker.number.float({ min: 0, max: 1000, precision: 0.01 }),
+  payment_amount = faker.number.float({ min: 0, max: 1000, multipleOf: 0.01 }),
   payment_currency = faker.finance.currencyCode(),
   payment_date = faker.date.recent(),
   payment_external_payment_id = faker.string.alpha(10),

--- a/tests/unit/core/services/subscriptions/payment.service.test.ts
+++ b/tests/unit/core/services/subscriptions/payment.service.test.ts
@@ -1,0 +1,100 @@
+import { PrismaClient } from "@prisma/client";
+
+import { PaymentEntity, PaymentPrisma } from "../../../../../src/core/entities/subscriptions/payment.entity";
+import {
+  createPaymentService,
+  deletePaymentService,
+  findPaymentService,
+  updatePaymentService,
+} from "../../../../../src/core/services/subscriptions/payment.service";
+import { genRandomPaymentPrisma } from "../../../../mocks/subscriptions/payment.mock";
+
+const paymentMock = jest.fn();
+const transactionMock = jest.fn();
+const disconnectMock = jest.fn();
+
+jest.mock("@prisma/client", () => {
+  return {
+    PrismaClient: jest.fn(() => {
+      return {
+        payment: {
+          findUnique: paymentMock,
+          create: paymentMock,
+          update: paymentMock,
+          delete: paymentMock,
+        },
+        $transaction: transactionMock,
+        $disconnect: disconnectMock,
+      };
+    }),
+  };
+});
+
+describe("Given a payment service", () => {
+  let prismaClient: PrismaClient;
+  let paymentPrisma: PaymentPrisma;
+  let payment: PaymentEntity;
+
+  beforeEach(() => {
+    prismaClient = new PrismaClient();
+    paymentPrisma = genRandomPaymentPrisma();
+    payment = PaymentEntity.fromPrisma(paymentPrisma);
+
+    paymentMock.mockImplementation(() => {
+      return paymentPrisma;
+    });
+    transactionMock.mockImplementation(() => {
+      return [paymentPrisma];
+    });
+  });
+
+  afterEach(() => {
+    paymentMock.mockClear();
+    transactionMock.mockClear();
+    disconnectMock.mockClear();
+  });
+
+  it("should get payment successfully", async () => {
+    const foundPayment = await findPaymentService(prismaClient, {
+      id: payment.getId(),
+    });
+
+    expect(foundPayment).toEqual(payment);
+    expect(paymentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create payment successfully", async () => {
+    const createdPayment = await createPaymentService(prismaClient, payment);
+
+    expect(createdPayment).toEqual(payment);
+    expect(paymentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should update payment successfully", async () => {
+    const updatedPayment = await updatePaymentService(
+      prismaClient,
+      {
+        id: payment.getId(),
+      },
+      {
+        amount: payment.getAmount(),
+        currency: payment.getCurrency(),
+        date: payment.getDate(),
+        externalPaymentId: payment.getExternalPaymentId(),
+        status: payment.getStatus(),
+      },
+    );
+
+    expect(updatedPayment).toEqual(payment);
+    expect(paymentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should delete payment successfully", async () => {
+    const deletedPayment = await deletePaymentService(prismaClient, {
+      id: payment.getId(),
+    });
+
+    expect(deletedPayment).toEqual(payment);
+    expect(paymentMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/core/services/subscriptions/subscription.service.test.ts
+++ b/tests/unit/core/services/subscriptions/subscription.service.test.ts
@@ -1,0 +1,109 @@
+import { PrismaClient } from "@prisma/client";
+
+import {
+  SubscriptionEntity,
+  SubscriptionPrisma,
+} from "../../../../../src/core/entities/subscriptions/subscription.entity";
+import {
+  createSubscriptionService,
+  deleteSubscriptionService,
+  findSubscriptionService,
+  updateSubscriptionService,
+} from "../../../../../src/core/services/subscriptions/subscription.service";
+import { genRandomSubscriptionPrisma } from "../../../../mocks/subscriptions/subscription.mock";
+
+const subscriptionMock = jest.fn();
+const transactionMock = jest.fn();
+const disconnectMock = jest.fn();
+
+jest.mock("@prisma/client", () => {
+  return {
+    PrismaClient: jest.fn(() => {
+      return {
+        subscription: {
+          findUnique: subscriptionMock,
+          create: subscriptionMock,
+          update: subscriptionMock,
+          delete: subscriptionMock,
+        },
+        $transaction: transactionMock,
+        $disconnect: disconnectMock,
+      };
+    }),
+  };
+});
+
+describe("Given a subscription service", () => {
+  let prismaClient: PrismaClient;
+  let subscriptionPrisma: SubscriptionPrisma;
+  let subscription: SubscriptionEntity;
+
+  beforeEach(() => {
+    prismaClient = new PrismaClient();
+    subscriptionPrisma = genRandomSubscriptionPrisma();
+    subscription = SubscriptionEntity.fromPrisma(subscriptionPrisma);
+
+    subscriptionMock.mockImplementation(() => {
+      return subscriptionPrisma;
+    });
+    transactionMock.mockImplementation(() => {
+      return [subscriptionPrisma];
+    });
+  });
+
+  afterEach(() => {
+    subscriptionMock.mockClear();
+    transactionMock.mockClear();
+    disconnectMock.mockClear();
+  });
+
+  it("should get subscription successfully", async () => {
+    const foundSubscription = await findSubscriptionService(prismaClient, {
+      id: subscription.getId(),
+    });
+
+    expect(foundSubscription).toEqual(subscription);
+    expect(subscriptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should create subscription successfully", async () => {
+    const createdSubscription = await createSubscriptionService(prismaClient, subscription);
+
+    expect(createdSubscription).toEqual(subscription);
+    expect(subscriptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should update subscription successfully", async () => {
+    const updatedSubscription = await updateSubscriptionService(
+      prismaClient,
+      {
+        id: subscription.getId(),
+      },
+      {
+        userId: subscription.getUserId(),
+        subscriptionPlanId: subscription.getSubscriptionPlanId(),
+        externalSubscriptionId: subscription.getExternalSubscriptionId(),
+        billingCycle: subscription.getBillingCycle(),
+        status: subscription.getStatus(),
+        isActive: subscription.getIsActive(),
+        renewsAt: subscription.getRenewsAt(),
+        startsAt: subscription.getStartsAt(),
+        endsAt: subscription.getEndsAt(),
+      },
+    );
+
+    expect(updatedSubscription).toEqual(subscription);
+    expect(subscriptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should delete subscription successfully", async () => {
+    const deletedSubscription = await deleteSubscriptionService(prismaClient, {
+      id: subscription.getId(),
+    });
+
+    expect(deletedSubscription).toEqual(subscription);
+    expect(subscriptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  // TODO: Add tests for testing errors
+});


### PR DESCRIPTION
This Pull Request introduces the implementation of CRUD (Create, Read, Update, Delete) services for managing Subscription and Payment entities within the application.

### Key Changes:
* *Subscription Services*:
   * Implemented services to create, retrieve, update, and delete subscriptions, facilitating efficient management of user subscriptions.
* *Payment Services:*
   * Developed CRUD functionalities for handling payment records, ensuring accurate tracking and processing of user payments.